### PR TITLE
Fix handling of changing precedence within lexical rules.

### DIFF
--- a/spec/compiler/helpers/rule_helpers.cc
+++ b/spec/compiler/helpers/rule_helpers.cc
@@ -39,6 +39,13 @@ namespace tree_sitter {
     return make_shared<rules::Metadata>(rule, values);
   }
 
+  rule_ptr active_prec(int precedence, rule_ptr rule) {
+    return std::make_shared<rules::Metadata>(rule, map<rules::MetadataKey, int>({
+      { rules::PRECEDENCE, precedence },
+      { rules::IS_ACTIVE, true }
+    }));
+  }
+
   bool operator==(const Variable &left, const Variable &right) {
     return left.name == right.name && left.rule->operator==(*right.rule) &&
       left.type == right.type;

--- a/spec/compiler/helpers/rule_helpers.h
+++ b/spec/compiler/helpers/rule_helpers.h
@@ -12,6 +12,7 @@ namespace tree_sitter {
   rule_ptr character(const std::set<uint32_t> &, bool sign);
   rule_ptr i_sym(size_t index);
   rule_ptr i_token(size_t index);
+  rule_ptr active_prec(int precedence, rule_ptr);
 
   bool operator==(const Variable &left, const Variable &right);
 }

--- a/spec/fixtures/parsers/c.c
+++ b/spec/fixtures/parsers/c.c
@@ -1803,7 +1803,7 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
             if (lookahead == '/')
                 ADVANCE(145);
             if (lookahead == '\\')
-                ADVANCE(149);
+                ADVANCE(153);
             if (!((lookahead == 0) ||
                 (lookahead == '\t') ||
                 (lookahead == '\n') ||
@@ -1811,7 +1811,7 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
                 (lookahead == ' ') ||
                 (lookahead == '/') ||
                 (lookahead == '\\')))
-                ADVANCE(151);
+                ADVANCE(155);
             LEX_ERROR();
         case 144:
             START_TOKEN();
@@ -1822,7 +1822,7 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
             if (lookahead == '/')
                 ADVANCE(145);
             if (lookahead == '\\')
-                ADVANCE(149);
+                ADVANCE(153);
             if (!((lookahead == 0) ||
                 (lookahead == '\t') ||
                 (lookahead == '\n') ||
@@ -1830,21 +1830,21 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
                 (lookahead == ' ') ||
                 (lookahead == '/') ||
                 (lookahead == '\\')))
-                ADVANCE(151);
+                ADVANCE(155);
             ACCEPT_TOKEN(sym_preproc_arg);
         case 145:
             if (lookahead == '*')
                 ADVANCE(146);
             if (lookahead == '/')
-                ADVANCE(154);
+                ADVANCE(151);
             if (lookahead == '\\')
-                ADVANCE(149);
+                ADVANCE(153);
             if (!((lookahead == 0) ||
                 (lookahead == '\n') ||
                 (lookahead == '*') ||
                 (lookahead == '/') ||
                 (lookahead == '\\')))
-                ADVANCE(151);
+                ADVANCE(155);
             ACCEPT_TOKEN(sym_preproc_arg);
         case 146:
             if (lookahead == '\n')
@@ -1852,7 +1852,7 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
             if (lookahead == '*')
                 ADVANCE(147);
             if (lookahead == '\\')
-                ADVANCE(152);
+                ADVANCE(149);
             if (!((lookahead == 0) ||
                 (lookahead == '\n') ||
                 (lookahead == '*') ||
@@ -1865,7 +1865,7 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
             if (lookahead == '/')
                 ADVANCE(148);
             if (lookahead == '\\')
-                ADVANCE(152);
+                ADVANCE(149);
             if (!((lookahead == 0) ||
                 (lookahead == '\n') ||
                 (lookahead == '/') ||
@@ -1873,75 +1873,77 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
                 ADVANCE(146);
             ACCEPT_TOKEN(sym_preproc_arg);
         case 148:
-            if (lookahead == '\\')
-                ADVANCE(149);
             ACCEPT_TOKEN(sym_comment);
         case 149:
             if (lookahead == '\n')
                 ADVANCE(150);
-            if (lookahead == '\\')
-                ADVANCE(149);
-            if (!((lookahead == 0) ||
-                (lookahead == '\n') ||
-                (lookahead == '\\')))
-                ADVANCE(151);
-            ACCEPT_TOKEN(sym_preproc_arg);
-        case 150:
-            if (lookahead == '\\')
-                ADVANCE(149);
-            if (!((lookahead == 0) ||
-                (lookahead == '\n') ||
-                (lookahead == '\\')))
-                ADVANCE(151);
-            ACCEPT_TOKEN(sym_preproc_arg);
-        case 151:
-            if (lookahead == '\\')
-                ADVANCE(149);
-            if (!((lookahead == 0) ||
-                (lookahead == '\n') ||
-                (lookahead == '\\')))
-                ADVANCE(151);
-            ACCEPT_TOKEN(sym_preproc_arg);
-        case 152:
-            if (lookahead == '\n')
-                ADVANCE(153);
             if (lookahead == '*')
                 ADVANCE(147);
             if (lookahead == '\\')
-                ADVANCE(152);
+                ADVANCE(149);
             if (!((lookahead == 0) ||
                 (lookahead == '\n') ||
                 (lookahead == '*') ||
                 (lookahead == '\\')))
                 ADVANCE(146);
             ACCEPT_TOKEN(sym_preproc_arg);
-        case 153:
+        case 150:
             if (lookahead == '\n')
                 ADVANCE(11);
             if (lookahead == '*')
                 ADVANCE(147);
             if (lookahead == '\\')
-                ADVANCE(152);
+                ADVANCE(149);
             if (!((lookahead == 0) ||
                 (lookahead == '\n') ||
                 (lookahead == '*') ||
                 (lookahead == '\\')))
                 ADVANCE(146);
             ACCEPT_TOKEN(sym_preproc_arg);
+        case 151:
+            if (lookahead == '\\')
+                ADVANCE(152);
+            if (!((lookahead == 0) ||
+                (lookahead == '\n') ||
+                (lookahead == '\\')))
+                ADVANCE(151);
+            ACCEPT_TOKEN(sym_comment);
+        case 152:
+            if (lookahead == '\\')
+                ADVANCE(152);
+            if (!((lookahead == 0) ||
+                (lookahead == '\n') ||
+                (lookahead == '\\')))
+                ADVANCE(151);
+            ACCEPT_TOKEN(sym_comment);
+        case 153:
+            if (lookahead == '\n')
+                ADVANCE(154);
+            if (lookahead == '\\')
+                ADVANCE(153);
+            if (!((lookahead == 0) ||
+                (lookahead == '\n') ||
+                (lookahead == '\\')))
+                ADVANCE(155);
+            ACCEPT_TOKEN(sym_preproc_arg);
         case 154:
             if (lookahead == '\\')
+                ADVANCE(153);
+            if (!((lookahead == 0) ||
+                (lookahead == '\n') ||
+                (lookahead == '\\')))
                 ADVANCE(155);
-            ACCEPT_TOKEN(sym_comment);
+            ACCEPT_TOKEN(sym_preproc_arg);
         case 155:
             if (lookahead == '\\')
+                ADVANCE(153);
+            if (!((lookahead == 0) ||
+                (lookahead == '\n') ||
+                (lookahead == '\\')))
                 ADVANCE(155);
-            ACCEPT_TOKEN(sym_comment);
+            ACCEPT_TOKEN(sym_preproc_arg);
         case 156:
             START_TOKEN();
-            if (lookahead == '/')
-                ADVANCE(145);
-            if (lookahead == '\\')
-                ADVANCE(149);
             ACCEPT_TOKEN(anon_sym_LF);
         case 157:
             START_TOKEN();
@@ -1956,8 +1958,6 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
             LEX_ERROR();
         case 158:
             START_TOKEN();
-            if (lookahead == '/')
-                ADVANCE(10);
             ACCEPT_TOKEN(anon_sym_LF);
         case 159:
             START_TOKEN();
@@ -2418,67 +2418,6 @@ static TSTree *ts_lex(TSLexer *lexer, TSStateId lex_state) {
             LEX_ERROR();
         case 178:
             START_TOKEN();
-            if (lookahead == 0)
-                ADVANCE(2);
-            if (lookahead == '\"')
-                ADVANCE(117);
-            if (lookahead == '#')
-                ADVANCE(3);
-            if (lookahead == '&')
-                ADVANCE(121);
-            if (lookahead == '(')
-                ADVANCE(97);
-            if (lookahead == ')')
-                ADVANCE(106);
-            if (lookahead == '*')
-                ADVANCE(98);
-            if (lookahead == '+')
-                ADVANCE(127);
-            if (lookahead == ',')
-                ADVANCE(134);
-            if (lookahead == '.')
-                ADVANCE(167);
-            if (lookahead == '/')
-                ADVANCE(10);
-            if ('0' <= lookahead && lookahead <= '9')
-                ADVANCE(122);
-            if (lookahead == ';')
-                ADVANCE(99);
-            if (lookahead == '=')
-                ADVANCE(161);
-            if (('A' <= lookahead && lookahead <= 'Z') ||
-                (lookahead == 'b') ||
-                (lookahead == 'd') ||
-                ('f' <= lookahead && lookahead <= 'k') ||
-                ('m' <= lookahead && lookahead <= 'q') ||
-                ('w' <= lookahead && lookahead <= 'z'))
-                ADVANCE(15);
-            if (lookahead == '[')
-                ADVANCE(114);
-            if (lookahead == ']')
-                ADVANCE(125);
-            if (lookahead == 'a')
-                ADVANCE(16);
-            if (lookahead == 'c')
-                ADVANCE(20);
-            if (lookahead == 'e')
-                ADVANCE(25);
-            if (lookahead == 'l')
-                ADVANCE(31);
-            if (lookahead == 'r')
-                ADVANCE(35);
-            if (lookahead == 's')
-                ADVANCE(49);
-            if (lookahead == 't')
-                ADVANCE(68);
-            if (lookahead == 'u')
-                ADVANCE(75);
-            if (lookahead == 'v')
-                ADVANCE(83);
-            if (lookahead == '{')
-                ADVANCE(104);
-            if (lookahead == '}')
-                ADVANCE(109);
             ACCEPT_TOKEN(anon_sym_LF);
         case ts_lex_state_error:
             START_TOKEN();

--- a/src/compiler/build_tables/lex_item.cc
+++ b/src/compiler/build_tables/lex_item.cc
@@ -34,7 +34,7 @@ bool LexItem::is_token_start() const {
     }
 
     bool apply_to(const rules::Metadata *rule) {
-      return (rule->value_for(rules::START_TOKEN) > 0) || apply(rule->rule);
+      return (rule->value_for(rules::START_TOKEN).second) || apply(rule->rule);
     }
 
     bool apply_to(const rules::Choice *rule) {
@@ -57,15 +57,15 @@ LexItem::CompletionStatus LexItem::completion_status() const {
         if (status.is_done)
           return status;
       }
-      return { false, 0, false };
+      return { false, PrecedenceRange(), false };
     }
 
     CompletionStatus apply_to(const rules::Metadata *rule) {
       CompletionStatus result = apply(rule->rule);
       if (result.is_done) {
-        if (!result.precedence && rule->value_for(rules::PRECEDENCE))
-          result.precedence = rule->value_for(rules::PRECEDENCE);
-        if (rule->value_for(rules::IS_STRING))
+        if (result.precedence.empty && rule->value_for(rules::PRECEDENCE).second)
+          result.precedence.add(rule->value_for(rules::PRECEDENCE).first);
+        if (rule->value_for(rules::IS_STRING).second)
           result.is_string = true;
       }
       return result;
@@ -76,7 +76,7 @@ LexItem::CompletionStatus LexItem::completion_status() const {
     }
 
     CompletionStatus apply_to(const rules::Blank *rule) {
-      return { true, 0, false };
+      return { true, PrecedenceRange(), false };
     }
 
     CompletionStatus apply_to(const rules::Seq *rule) {
@@ -84,7 +84,7 @@ LexItem::CompletionStatus LexItem::completion_status() const {
       if (left_status.is_done)
         return apply(rule->right);
       else
-        return { false, 0, false };
+        return { false, PrecedenceRange(), false };
     }
   };
 

--- a/src/compiler/build_tables/lex_item.h
+++ b/src/compiler/build_tables/lex_item.h
@@ -18,7 +18,7 @@ class LexItem {
 
   struct CompletionStatus {
     bool is_done;
-    int precedence;
+    PrecedenceRange precedence;
     bool is_string;
   };
 

--- a/src/compiler/prepare_grammar/extract_tokens.cc
+++ b/src/compiler/prepare_grammar/extract_tokens.cc
@@ -79,7 +79,7 @@ class TokenExtractor : public rules::IdentityRuleFn {
   }
 
   rule_ptr apply_to(const rules::Metadata *rule) {
-    if (rule->value_for(rules::IS_TOKEN) > 0)
+    if (rule->value_for(rules::IS_TOKEN).second)
       return apply_to_token(rule->rule.get(), VariableTypeAuxiliary);
     else
       return rules::IdentityRuleFn::apply_to(rule);

--- a/src/compiler/prepare_grammar/flatten_grammar.cc
+++ b/src/compiler/prepare_grammar/flatten_grammar.cc
@@ -29,23 +29,23 @@ class FlattenRule : public rules::RuleFn<void> {
   }
 
   void apply_to(const rules::Metadata *metadata) {
-    int precedence = metadata->value_for(rules::PRECEDENCE);
-    int associativity = metadata->value_for(rules::ASSOCIATIVITY);
+    auto precedence = metadata->value_for(rules::PRECEDENCE);
+    auto associativity = metadata->value_for(rules::ASSOCIATIVITY);
 
-    if (precedence != 0)
-      precedence_stack.push_back(precedence);
-    if (associativity != 0)
+    if (precedence.second)
+      precedence_stack.push_back(precedence.first);
+    if (associativity.second)
       associativity_stack.push_back(
-        static_cast<rules::Associativity>(associativity));
+        static_cast<rules::Associativity>(associativity.first));
 
     apply(metadata->rule);
 
-    if (precedence != 0) {
+    if (precedence.second) {
       precedence_stack.pop_back();
       production.back().precedence = precedence_stack.back();
     }
 
-    if (associativity != 0) {
+    if (associativity.second) {
       associativity_stack.pop_back();
       production.back().associativity = associativity_stack.back();
     }

--- a/src/compiler/prepare_grammar/is_token.cc
+++ b/src/compiler/prepare_grammar/is_token.cc
@@ -18,7 +18,7 @@ class IsToken : public rules::RuleFn<bool> {
   }
 
   bool apply_to(const rules::Metadata *rule) {
-    return rule->value_for(rules::IS_TOKEN);
+    return rule->value_for(rules::IS_TOKEN).second;
   }
 };
 

--- a/src/compiler/rules/metadata.cc
+++ b/src/compiler/rules/metadata.cc
@@ -10,6 +10,7 @@ namespace rules {
 using std::hash;
 using std::make_shared;
 using std::map;
+using std::pair;
 
 Metadata::Metadata(rule_ptr rule, map<MetadataKey, int> values)
     : rule(rule), value(values) {}
@@ -36,13 +37,20 @@ rule_ptr Metadata::copy() const {
   return make_shared<Metadata>(rule->copy(), value);
 }
 
-int Metadata::value_for(MetadataKey key) const {
-  auto pair = value.find(key);
-  return (pair != value.end()) ? pair->second : 0;
+pair<int, bool> Metadata::value_for(MetadataKey key) const {
+  auto entry = value.find(key);
+  if (entry == value.end())
+    return {0, false};
+  else
+    return {entry->second, true};
 }
 
 std::string Metadata::to_string() const {
-  return "(metadata " + rule->to_string() + ")";
+  auto precedence = value_for(rules::PRECEDENCE);
+  if (precedence.second && value_for(rules::IS_ACTIVE).second)
+    return "(metadata prec:" + std::to_string(precedence.first) + " " + rule->to_string() + ")";
+  else
+    return "(metadata " + rule->to_string() + ")";
 }
 
 void Metadata::accept(Visitor *visitor) const {

--- a/src/compiler/rules/metadata.h
+++ b/src/compiler/rules/metadata.h
@@ -21,6 +21,7 @@ enum MetadataKey {
   ASSOCIATIVITY,
   IS_TOKEN,
   IS_STRING,
+  IS_ACTIVE,
 };
 
 class Metadata : public Rule {
@@ -33,7 +34,7 @@ class Metadata : public Rule {
   rule_ptr copy() const;
   std::string to_string() const;
   void accept(Visitor *visitor) const;
-  int value_for(MetadataKey key) const;
+  std::pair<int, bool> value_for(MetadataKey key) const;
 
   const rule_ptr rule;
   const std::map<MetadataKey, int> value;


### PR DESCRIPTION
A precedence annotation wrapping a sequence of characters now only affects how
tightly those characters bind to *each other*, not how tightly they bind to the
preceding character.

This bug surfaced because a generated lexer was failing to recognize a `\n` character as a token, instead treating it as ubiquitous whitespace. It made this error because, even though anonymous ubiquitous tokens have the lowest possible precedence, the character immediately *after* the `\n` was part of a normal token, which had *normal* precedence (0). So the action of advancing into that following token was incorrectly prioritized above the correct action: accepting the line-break token.

Refs https://github.com/robrix/tree-sitter-swift/pull/9