### PR TITLE
Clean up API a bit after the addition of row/column tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,18 @@ int main() {
 
   TSNode root_node = ts_document_root_node(document);
   printf(
-    "Root name: %s, position: %lu, size: %lu\n",
+    "Root name: %s, start: %lu, end: %lu\n",
     ts_node_name(root_node, document),
-    ts_node_pos(root_node).chars,
-    ts_node_size(root_node).chars
+    ts_node_start_char(root_node),
+    ts_node_end_char(root_node)
   );
 
   TSNode product_node = ts_node_named_child(ts_node_child(root_node, 0), 1);
   printf(
-    "Child name: %s, position: %lu, size: %lu\n",
+    "Child name: %s, start: %lu, end: %lu\n",
     ts_node_name(product_node, document),
-    ts_node_pos(product_node).chars,
-    ts_node_size(product_node).chars
+    ts_node_start_char(product_node),
+    ts_node_end_char(product_node)
   );
 
   ts_document_free(document);

--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -19,6 +19,8 @@ typedef unsigned short TSStateId;
 typedef struct {
   size_t bytes;
   size_t chars;
+  size_t rows;
+  size_t columns;
 } TSLength;
 
 typedef struct {
@@ -41,10 +43,6 @@ typedef struct TSLexer {
   TSLength current_position;
   TSLength token_end_position;
   TSLength token_start_position;
-
-  TSPoint current_point;
-  TSPoint token_end_point;
-  TSPoint token_start_point;
 
   size_t lookahead_size;
   int32_t lookahead;

--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -17,6 +17,11 @@ typedef struct TSTree TSTree;
 typedef unsigned short TSStateId;
 
 typedef struct {
+  size_t bytes;
+  size_t chars;
+} TSLength;
+
+typedef struct {
   bool visible : 1;
   bool named : 1;
   bool extra : 1;

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -16,7 +16,7 @@ typedef struct {
 typedef struct {
   void *payload;
   const char *(*read_fn)(void *payload, size_t *bytes_read);
-  int (*seek_fn)(void *payload, TSLength position);
+  int (*seek_fn)(void *payload, size_t character, size_t byte);
 } TSInput;
 
 typedef enum {

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -50,9 +50,10 @@ typedef unsigned short TSSymbol;
 typedef struct TSLanguage TSLanguage;
 typedef struct TSDocument TSDocument;
 
-TSLength ts_node_pos(TSNode);
-TSLength ts_node_size(TSNode);
-TSPoint ts_node_size_point(TSNode);
+size_t ts_node_start_char(TSNode);
+size_t ts_node_end_char(TSNode);
+size_t ts_node_start_byte(TSNode);
+size_t ts_node_end_byte(TSNode);
 TSPoint ts_node_start_point(TSNode);
 TSPoint ts_node_end_point(TSNode);
 TSSymbol ts_node_symbol(TSNode);
@@ -70,8 +71,8 @@ TSNode ts_node_next_sibling(TSNode);
 TSNode ts_node_next_named_sibling(TSNode);
 TSNode ts_node_prev_sibling(TSNode);
 TSNode ts_node_prev_named_sibling(TSNode);
-TSNode ts_node_descendent_for_range(TSNode, size_t, size_t);
-TSNode ts_node_named_descendent_for_range(TSNode, size_t, size_t);
+TSNode ts_node_descendant_for_range(TSNode, size_t, size_t);
+TSNode ts_node_named_descendant_for_range(TSNode, size_t, size_t);
 
 TSDocument *ts_document_make();
 void ts_document_free(TSDocument *);

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -9,11 +9,6 @@ extern "C" {
 #include <stdbool.h>
 
 typedef struct {
-  size_t bytes;
-  size_t chars;
-} TSLength;
-
-typedef struct {
   void *payload;
   const char *(*read_fn)(void *payload, size_t *bytes_read);
   int (*seek_fn)(void *payload, size_t character, size_t byte);
@@ -42,8 +37,7 @@ typedef struct {
 
 typedef struct {
   const void *data;
-  TSLength offset;
-  size_t row;
+  size_t offset[3];
 } TSNode;
 
 typedef unsigned short TSSymbol;
@@ -51,10 +45,10 @@ typedef struct TSLanguage TSLanguage;
 typedef struct TSDocument TSDocument;
 
 size_t ts_node_start_char(TSNode);
-size_t ts_node_end_char(TSNode);
 size_t ts_node_start_byte(TSNode);
-size_t ts_node_end_byte(TSNode);
 TSPoint ts_node_start_point(TSNode);
+size_t ts_node_end_char(TSNode);
+size_t ts_node_end_byte(TSNode);
 TSPoint ts_node_end_point(TSNode);
 TSSymbol ts_node_symbol(TSNode);
 const char *ts_node_name(TSNode, const TSDocument *);

--- a/spec/runtime/helpers/spy_input.cc
+++ b/spec/runtime/helpers/spy_input.cc
@@ -84,11 +84,11 @@ const char * SpyInput::read(void *payload, size_t *bytes_read) {
   return spy->buffer;
 }
 
-int SpyInput::seek(void *payload, TSLength position) {
+int SpyInput::seek(void *payload, size_t character, size_t byte) {
   auto spy = static_cast<SpyInput *>(payload);
   if (spy->strings_read.size() == 0 || spy->strings_read.back().size() > 0)
     spy->strings_read.push_back("");
-  spy->byte_offset = position.bytes;
+  spy->byte_offset = byte;
   return 0;
 }
 

--- a/spec/runtime/helpers/spy_input.h
+++ b/spec/runtime/helpers/spy_input.h
@@ -19,7 +19,7 @@ class SpyInput {
   std::vector<SpyInputEdit> undo_stack;
 
   static const char * read(void *, size_t *);
-  static int seek(void *, TSLength);
+  static int seek(void *, size_t, size_t);
   std::string swap_substr(size_t, size_t, std::string);
 
  public:

--- a/spec/runtime/helpers/tree_helpers.cc
+++ b/spec/runtime/helpers/tree_helpers.cc
@@ -24,7 +24,7 @@ ostream &operator<<(std::ostream &stream, const TSTree *tree) {
 
 ostream &operator<<(ostream &stream, const TSNode &node) {
   return stream << string("{") << (const TSTree *)node.data <<
-    string(", ") << to_string(ts_node_pos(node).chars) << string("}");
+    string(", ") << to_string(ts_node_start_char(node)) << string("}");
 }
 
 bool operator==(const TSNode &left, const TSNode &right) {

--- a/spec/runtime/helpers/tree_helpers.cc
+++ b/spec/runtime/helpers/tree_helpers.cc
@@ -1,4 +1,5 @@
 #include "runtime/helpers/tree_helpers.h"
+#include <ostream>
 
 using std::string;
 using std::to_string;
@@ -32,6 +33,6 @@ bool operator==(const TSNode &left, const TSNode &right) {
 }
 
 ostream &operator<<(ostream &stream, const TSLength &length) {
-  return stream << string("{") << to_string(length.chars) << string(", ") <<
-    to_string(length.bytes) << string("}");
+  return stream << "{chars:" << length.chars << ", bytes:" <<
+    length.bytes << ", rows:" << length.rows << ", columns:" << length.columns << "}";
 }

--- a/spec/runtime/language_specs.cc
+++ b/spec/runtime/language_specs.cc
@@ -20,10 +20,9 @@ void expect_the_correct_tree(TSNode node, TSDocument *doc, string tree_string) {
 }
 
 void expect_a_consistent_tree(TSNode node, TSDocument *doc) {
-  TSLength start = ts_node_pos(node);
-  TSLength end = ts_length_add(start, ts_node_size(node));
   size_t child_count = ts_node_child_count(node);
-
+  size_t start = ts_node_start_char(node);
+  size_t end = ts_node_end_char(node);
   TSPoint start_point = ts_node_start_point(node);
   TSPoint end_point = ts_node_end_point(node);
 
@@ -32,15 +31,13 @@ void expect_a_consistent_tree(TSNode node, TSDocument *doc) {
 
   for (size_t i = 0; i < child_count; i++) {
     TSNode child = ts_node_child(node, i);
-    TSLength child_start = ts_node_pos(child);
-    TSLength child_end = ts_length_add(child_start, ts_node_size(child));
-
+    size_t child_start = ts_node_start_char(child);
+    size_t child_end = ts_node_end_char(child);
     TSPoint child_start_point = ts_node_start_point(child);
     TSPoint child_end_point = ts_node_end_point(child);
 
-    AssertThat(child_start.chars, IsGreaterThan(start.chars) || Equals(start.chars));
-    AssertThat(child_end.chars, IsLessThan(end.chars) || Equals(end.chars));
-
+    AssertThat(child_start, IsGreaterThan(start) || Equals(start));
+    AssertThat(child_end, IsLessThan(end) || Equals(end));
     AssertThat(child_start_point, IsGreaterThan(start_point) || Equals(start_point));
     AssertThat(child_end_point, IsLessThan(end_point) || Equals(end_point));
 

--- a/spec/runtime/node_spec.cc
+++ b/spec/runtime/node_spec.cc
@@ -9,21 +9,34 @@ START_TEST
 describe("Node", []() {
   TSDocument *document;
   TSNode array_node;
-  string input_string;
+  string input_string = "\n"
+    "\n"
+    "[\n"
+    "  123,\n"
+    "  false,\n"
+    "  {\n"
+    "    \"x\": null\n"
+    "  }\n"
+    "]";
+
+  size_t array_index = input_string.find("[\n");
+  size_t array_end_index = input_string.find("]") + 1;
+  size_t number_index = input_string.find("123");
+  size_t number_end_index = number_index + string("123").size();
+  size_t false_index = input_string.find("false");
+  size_t false_end_index = false_index + string("false").size();
+  size_t object_index = input_string.find("{");
+  size_t object_end_index = input_string.find("}") + 1;
+  size_t string_index = input_string.find("\"x\"");
+  size_t string_end_index = string_index + 3;
+  size_t colon_index = input_string.find(":");
+  size_t null_index = input_string.find("null");
+  size_t null_end_index = null_index + string("null").size();
 
   before_each([&]() {
     document = ts_document_make();
     ts_document_set_language(document, ts_language_json());
 
-    input_string = "\n"
-      "\n"
-      "[\n"
-      "  123,\n"
-      "  false,\n"
-      "  {\n"
-      "    \"x\": null\n"
-      "  }\n"
-      "]";
 
     ts_document_set_input_string(document, input_string.c_str());
     ts_document_parse(document);
@@ -53,27 +66,27 @@ describe("Node", []() {
       AssertThat(ts_node_name(child2, document), Equals("false"));
       AssertThat(ts_node_name(child3, document), Equals("object"));
 
-      AssertThat(ts_node_pos(array_node).bytes, Equals<size_t>(2));
-      AssertThat(ts_node_size(array_node).bytes, Equals<size_t>(41));
-
+      AssertThat(ts_node_start_byte(array_node), Equals(array_index));
+      AssertThat(ts_node_end_byte(array_node), Equals(array_end_index));
+      AssertThat(ts_node_start_char(array_node), Equals(array_index));
+      AssertThat(ts_node_end_char(array_node), Equals(array_end_index));
       AssertThat(ts_node_start_point(array_node), Equals<TSPoint>({ 2, 0 }));
       AssertThat(ts_node_end_point(array_node), Equals<TSPoint>({ 8, 1 }));
 
-      AssertThat(ts_node_pos(child1).bytes, Equals(input_string.find("123")));
-      AssertThat(ts_node_size(child1).bytes, Equals<size_t>(3));
-
+      AssertThat(ts_node_start_byte(child1), Equals(number_index));
+      AssertThat(ts_node_end_byte(child1), Equals(number_end_index));
+      AssertThat(ts_node_start_char(child1), Equals(number_index));
+      AssertThat(ts_node_end_char(child1), Equals(number_end_index));
       AssertThat(ts_node_start_point(child1), Equals<TSPoint>({ 3, 2 }));
       AssertThat(ts_node_end_point(child1), Equals<TSPoint>({ 3, 5 }));
 
-      AssertThat(ts_node_pos(child2).bytes, Equals(input_string.find("false")));
-      AssertThat(ts_node_size(child2).bytes, Equals<size_t>(5));
-
+      AssertThat(ts_node_start_byte(child2), Equals(false_index));
+      AssertThat(ts_node_end_byte(child2), Equals(false_end_index));
       AssertThat(ts_node_start_point(child2), Equals<TSPoint>({ 4, 2 }));
       AssertThat(ts_node_end_point(child2), Equals<TSPoint>({ 4, 7 }));
 
-      AssertThat(ts_node_pos(child3).bytes, Equals(input_string.find("{")));
-      AssertThat(ts_node_size(child3).bytes, Equals<size_t>(19));
-
+      AssertThat(ts_node_start_byte(child3), Equals(object_index));
+      AssertThat(ts_node_end_byte(child3), Equals(object_end_index));
       AssertThat(ts_node_start_point(child3), Equals<TSPoint>({ 5, 2 }));
       AssertThat(ts_node_end_point(child3), Equals<TSPoint>({ 7, 3 }));
 
@@ -85,9 +98,18 @@ describe("Node", []() {
       AssertThat(ts_node_name(grandchild1, document), Equals("string"));
       AssertThat(ts_node_name(grandchild2, document), Equals("null"));
 
+      AssertThat(ts_node_start_byte(grandchild1), Equals(string_index));
+      AssertThat(ts_node_end_byte(grandchild1), Equals(string_end_index));
       AssertThat(ts_node_start_point(grandchild1), Equals<TSPoint>({ 6, 4 }));
       AssertThat(ts_node_end_point(grandchild1), Equals<TSPoint>({ 6, 7 }));
 
+      AssertThat(ts_node_start_byte(grandchild2), Equals(null_index));
+      AssertThat(ts_node_end_byte(grandchild2), Equals(null_end_index));
+      AssertThat(ts_node_start_point(grandchild2), Equals<TSPoint>({ 6, 9 }));
+      AssertThat(ts_node_end_point(grandchild2), Equals<TSPoint>({ 6, 13 }));
+
+      AssertThat(ts_node_parent(grandchild1), Equals(child3));
+      AssertThat(ts_node_parent(grandchild2), Equals(child3));
       AssertThat(ts_node_parent(child1), Equals(array_node));
       AssertThat(ts_node_parent(child2), Equals(array_node));
       AssertThat(ts_node_parent(child3), Equals(array_node));
@@ -124,27 +146,23 @@ describe("Node", []() {
       AssertThat(ts_node_is_named(child6), IsTrue());
       AssertThat(ts_node_is_named(child7), IsFalse());
 
-      AssertThat(ts_node_pos(child1).bytes, Equals<size_t>(2));
-      AssertThat(ts_node_size(child1).bytes, Equals<size_t>(1));
-
+      AssertThat(ts_node_start_byte(child1), Equals(array_index));
+      AssertThat(ts_node_end_byte(child1), Equals(array_index + 1));
       AssertThat(ts_node_start_point(child1), Equals<TSPoint>({ 2, 0 }));
       AssertThat(ts_node_end_point(child1), Equals<TSPoint>({ 2, 1 }));
 
-      AssertThat(ts_node_pos(child3).bytes, Equals<size_t>(9));
-      AssertThat(ts_node_size(child3).bytes, Equals<size_t>(1));
-
+      AssertThat(ts_node_start_byte(child3), Equals(number_end_index));
+      AssertThat(ts_node_end_byte(child3), Equals(number_end_index + 1));
       AssertThat(ts_node_start_point(child3), Equals<TSPoint>({ 3, 5 }));
       AssertThat(ts_node_end_point(child3), Equals<TSPoint>({ 3, 6 }));
 
-      AssertThat(ts_node_pos(child5).bytes, Equals<size_t>(18));
-      AssertThat(ts_node_size(child5).bytes, Equals<size_t>(1));
-
+      AssertThat(ts_node_start_byte(child5), Equals(false_end_index));
+      AssertThat(ts_node_end_byte(child5), Equals(false_end_index + 1));
       AssertThat(ts_node_start_point(child5), Equals<TSPoint>({ 4, 7 }));
       AssertThat(ts_node_end_point(child5), Equals<TSPoint>({ 4, 8 }));
 
-      AssertThat(ts_node_pos(child7).bytes, Equals<size_t>(42));
-      AssertThat(ts_node_size(child7).bytes, Equals<size_t>(1));
-
+      AssertThat(ts_node_start_byte(child7), Equals(array_end_index - 1));
+      AssertThat(ts_node_end_byte(child7), Equals(array_end_index));
       AssertThat(ts_node_start_point(child7), Equals<TSPoint>({ 8, 0 }));
       AssertThat(ts_node_end_point(child7), Equals<TSPoint>({ 8, 1 }));
 
@@ -162,6 +180,11 @@ describe("Node", []() {
       AssertThat(ts_node_name(grandchild4, document), Equals("null"));
       AssertThat(ts_node_name(grandchild5, document), Equals("}"));
 
+      AssertThat(ts_node_parent(grandchild1), Equals(child6));
+      AssertThat(ts_node_parent(grandchild2), Equals(child6));
+      AssertThat(ts_node_parent(grandchild3), Equals(child6));
+      AssertThat(ts_node_parent(grandchild4), Equals(child6));
+      AssertThat(ts_node_parent(grandchild5), Equals(child6));
       AssertThat(ts_node_parent(child1), Equals(array_node));
       AssertThat(ts_node_parent(child2), Equals(array_node));
       AssertThat(ts_node_parent(child3), Equals(array_node));
@@ -252,16 +275,17 @@ describe("Node", []() {
   describe("named_descendant_for_range(start, end)", [&]() {
     describe("when there is a leaf node that spans the given range exactly", [&]() {
       it("returns that leaf node", [&]() {
-        TSNode leaf = ts_node_named_descendent_for_range(array_node, 28, 30);
+        TSNode leaf = ts_node_named_descendant_for_range(array_node, string_index, string_end_index - 1);
         AssertThat(ts_node_name(leaf, document), Equals("string"));
-        AssertThat(ts_node_size(leaf).bytes, Equals<size_t>(3));
-        AssertThat(ts_node_pos(leaf).bytes, Equals<size_t>(28));
+        AssertThat(ts_node_start_byte(leaf), Equals(string_index));
+        AssertThat(ts_node_end_byte(leaf), Equals(string_end_index));
+        AssertThat(ts_node_start_point(leaf), Equals<TSPoint>({ 6, 4 }));
+        AssertThat(ts_node_end_point(leaf), Equals<TSPoint>({ 6, 7 }));
 
-        size_t index = input_string.find("123");
-        leaf = ts_node_named_descendent_for_range(array_node, index, index + 2);
+        leaf = ts_node_named_descendant_for_range(array_node, number_index, number_end_index - 1);
         AssertThat(ts_node_name(leaf, document), Equals("number"));
-        AssertThat(ts_node_pos(leaf).bytes, Equals(index));
-        AssertThat(ts_node_size(leaf).bytes, Equals<size_t>(3));
+        AssertThat(ts_node_start_byte(leaf), Equals(number_index));
+        AssertThat(ts_node_end_byte(leaf), Equals(number_end_index));
         AssertThat(ts_node_start_point(leaf), Equals<TSPoint>({ 3, 2 }));
         AssertThat(ts_node_end_point(leaf), Equals<TSPoint>({ 3, 5 }));
       });
@@ -269,20 +293,17 @@ describe("Node", []() {
 
     describe("when there is a leaf node that extends beyond the given range", [&]() {
       it("returns that leaf node", [&]() {
-        size_t index = input_string.find("\"x\"");
-        TSNode leaf = ts_node_named_descendent_for_range(array_node, index, index + 1);
+        TSNode leaf = ts_node_named_descendant_for_range(array_node, string_index, string_index + 1);
         AssertThat(ts_node_name(leaf, document), Equals("string"));
-        AssertThat(ts_node_pos(leaf).bytes, Equals(index));
-        AssertThat(ts_node_size(leaf).bytes, Equals<size_t>(3));
-
+        AssertThat(ts_node_start_byte(leaf), Equals(string_index));
+        AssertThat(ts_node_end_byte(leaf), Equals(string_end_index));
         AssertThat(ts_node_start_point(leaf), Equals<TSPoint>({ 6, 4 }));
         AssertThat(ts_node_end_point(leaf), Equals<TSPoint>({ 6, 7 }));
 
-        leaf = ts_node_named_descendent_for_range(array_node, index + 1, index + 2);
+        leaf = ts_node_named_descendant_for_range(array_node, string_index + 1, string_index + 2);
         AssertThat(ts_node_name(leaf, document), Equals("string"));
-        AssertThat(ts_node_pos(leaf).bytes, Equals<size_t>(index));
-        AssertThat(ts_node_size(leaf).bytes, Equals<size_t>(3));
-
+        AssertThat(ts_node_start_byte(leaf), Equals(string_index));
+        AssertThat(ts_node_end_byte(leaf), Equals(string_end_index));
         AssertThat(ts_node_start_point(leaf), Equals<TSPoint>({ 6, 4 }));
         AssertThat(ts_node_end_point(leaf), Equals<TSPoint>({ 6, 7 }));
       });
@@ -290,49 +311,38 @@ describe("Node", []() {
 
     describe("when there is no leaf node that spans the given range", [&]() {
       it("returns the smallest node that does span the range", [&]() {
-        size_t index = input_string.find("\"x\"");
-        TSNode node = ts_node_named_descendent_for_range(array_node, index, index + 3);
+        TSNode node = ts_node_named_descendant_for_range(array_node, string_index, string_index + 3);
         AssertThat(ts_node_name(node, document), Equals("object"));
-
-        size_t object_index = input_string.find("{");
-        AssertThat(ts_node_pos(node).bytes, Equals<size_t>(object_index));
-        AssertThat(ts_node_size(node).bytes, Equals<size_t>(19));
-
+        AssertThat(ts_node_start_byte(node), Equals(object_index));
+        AssertThat(ts_node_end_byte(node), Equals(object_end_index));
         AssertThat(ts_node_start_point(node), Equals<TSPoint>({ 5, 2 }));
         AssertThat(ts_node_end_point(node), Equals<TSPoint>({ 7, 3 }));
       });
 
       it("does not return invisible nodes (repeats)", [&]() {
-        size_t comma_index = input_string.find(",");
-        TSNode node = ts_node_named_descendent_for_range(array_node, comma_index, comma_index + 1);
+        TSNode node = ts_node_named_descendant_for_range(array_node, number_end_index, number_end_index + 1);
         AssertThat(ts_node_name(node, document), Equals("array"));
-        size_t array_index = input_string.find("[");
-        AssertThat(ts_node_pos(node).bytes, Equals<size_t>(array_index));
-        AssertThat(ts_node_size(node).bytes, Equals<size_t>(41));
-
+        AssertThat(ts_node_start_byte(node), Equals(array_index));
+        AssertThat(ts_node_end_byte(node), Equals(array_end_index));
         AssertThat(ts_node_start_point(node), Equals<TSPoint>({ 2, 0 }));
         AssertThat(ts_node_end_point(node), Equals<TSPoint>({ 8, 1 }));
       });
     });
   });
 
-  describe("descendent_for_range(start, end)", [&]() {
+  describe("descendant_for_range(start, end)", [&]() {
     it("returns the smallest concrete node that spans the given range", [&]() {
-      size_t colon_index = input_string.find(":");
-      TSNode node1 = ts_node_descendent_for_range(array_node, colon_index, colon_index);
+      TSNode node1 = ts_node_descendant_for_range(array_node, colon_index, colon_index);
       AssertThat(ts_node_name(node1, document), Equals(":"));
-      AssertThat(ts_node_pos(node1).bytes, Equals<size_t>(colon_index));
-      AssertThat(ts_node_size(node1).bytes, Equals<size_t>(1));
+      AssertThat(ts_node_start_byte(node1), Equals(colon_index));
+      AssertThat(ts_node_end_byte(node1), Equals(colon_index + 1));
       AssertThat(ts_node_start_point(node1), Equals<TSPoint>({ 6, 7 }));
       AssertThat(ts_node_end_point(node1), Equals<TSPoint>({ 6, 8 }));
 
-      size_t index = input_string.find("\":");
-      TSNode node2 = ts_node_descendent_for_range(array_node, index, index + 2);
+      TSNode node2 = ts_node_descendant_for_range(array_node, string_index + 2, string_index + 4);
       AssertThat(ts_node_name(node2, document), Equals("object"));
-
-      size_t object_index = input_string.find("{");
-      AssertThat(ts_node_pos(node2).bytes, Equals<size_t>(object_index));
-      AssertThat(ts_node_size(node2).bytes, Equals<size_t>(19));
+      AssertThat(ts_node_start_byte(node2), Equals(object_index));
+      AssertThat(ts_node_end_byte(node2), Equals(object_end_index));
       AssertThat(ts_node_start_point(node2), Equals<TSPoint>({ 5, 2 }));
       AssertThat(ts_node_end_point(node2), Equals<TSPoint>({ 7, 3 }));
     });

--- a/spec/runtime/parser_spec.cc
+++ b/spec/runtime/parser_spec.cc
@@ -32,38 +32,38 @@ describe("Parser", [&]() {
     ts_document_parse(doc);
 
     root = ts_document_root_node(doc);
-    AssertThat(ts_node_size(root).bytes + ts_node_pos(root).bytes, Equals(strlen(text)));
+    AssertThat(ts_node_end_byte(root), Equals(strlen(text)));
     input->clear();
   };
 
   auto insert_text = [&](size_t position, string text) {
-    size_t prev_size = ts_node_size(root).bytes + ts_node_pos(root).bytes;
+    size_t prev_size = ts_node_end_byte(root);
     ts_document_edit(doc, input->replace(position, 0, text));
     ts_document_parse(doc);
 
     root = ts_document_root_node(doc);
-    size_t new_size = ts_node_size(root).bytes + ts_node_pos(root).bytes;
+    size_t new_size = ts_node_end_byte(root);
     AssertThat(new_size, Equals(prev_size + text.size()));
   };
 
   auto delete_text = [&](size_t position, size_t length) {
-    size_t prev_size = ts_node_size(root).bytes + ts_node_pos(root).bytes;
+    size_t prev_size = ts_node_end_byte(root);
     ts_document_edit(doc, input->replace(position, length, ""));
     ts_document_parse(doc);
 
     root = ts_document_root_node(doc);
-    size_t new_size = ts_node_size(root).bytes + ts_node_pos(root).bytes;
+    size_t new_size = ts_node_end_byte(root);
     AssertThat(new_size, Equals(prev_size - length));
   };
 
   auto replace_text = [&](size_t position, size_t length, string new_text) {
-    size_t prev_size = ts_node_size(root).bytes + ts_node_pos(root).bytes;
+    size_t prev_size = ts_node_end_byte(root);
 
     ts_document_edit(doc, input->replace(position, length, new_text));
     ts_document_parse(doc);
 
     root = ts_document_root_node(doc);
-    size_t new_size = ts_node_size(root).bytes + ts_node_pos(root).bytes;
+    size_t new_size = ts_node_end_byte(root);
     AssertThat(new_size, Equals(prev_size - length + new_text.size()));
   };
 
@@ -83,11 +83,11 @@ describe("Parser", [&]() {
         TSNode last = ts_node_named_child(root, 2);
 
         AssertThat(ts_node_name(error, doc), Equals("ERROR"));
-        AssertThat(ts_node_pos(error).bytes, Equals(strlen("  [123,  ")))
-        AssertThat(ts_node_size(error).bytes, Equals(strlen("@@@@@")))
+        AssertThat(ts_node_start_byte(error), Equals(strlen("  [123,  ")));
+        AssertThat(ts_node_end_byte(error), Equals(strlen("  [123,  @@@@@")));
 
         AssertThat(ts_node_name(last, doc), Equals("true"));
-        AssertThat(ts_node_pos(last).bytes, Equals(strlen("  [123,  @@@@@,   ")))
+        AssertThat(ts_node_start_byte(last), Equals(strlen("  [123,  @@@@@,   ")))
       });
     });
 
@@ -104,11 +104,11 @@ describe("Parser", [&]() {
         AssertThat(ts_node_symbol(error), Equals(ts_builtin_sym_error));
 
         AssertThat(ts_node_name(error, doc), Equals("ERROR"));
-        AssertThat(ts_node_pos(error).bytes, Equals(strlen("  [123, ")))
-        AssertThat(ts_node_size(error).bytes, Equals(strlen("faaaaalse")))
+        AssertThat(ts_node_start_byte(error), Equals(strlen("  [123, ")))
+        AssertThat(ts_node_end_byte(error), Equals(strlen("  [123, faaaaalse")))
 
         AssertThat(ts_node_name(last, doc), Equals("true"));
-        AssertThat(ts_node_pos(last).bytes, Equals(strlen("  [123, faaaaalse, ")));
+        AssertThat(ts_node_start_byte(last), Equals(strlen("  [123, faaaaalse, ")));
       });
     });
 
@@ -123,11 +123,11 @@ describe("Parser", [&]() {
         TSNode last = ts_node_named_child(root, 2);
 
         AssertThat(ts_node_name(error, doc), Equals("ERROR"));
-        AssertThat(ts_node_pos(error).bytes, Equals(strlen("  [123, ")));
-        AssertThat(ts_node_size(error).bytes, Equals(strlen("true false")));
+        AssertThat(ts_node_start_byte(error), Equals(strlen("  [123, ")));
+        AssertThat(ts_node_end_byte(error), Equals(strlen("  [123, true false")));
 
         AssertThat(ts_node_name(last, doc), Equals("true"));
-        AssertThat(ts_node_pos(last).bytes, Equals(strlen("  [123, true false, ")));
+        AssertThat(ts_node_start_byte(last), Equals(strlen("  [123, true false, ")));
       });
     });
 
@@ -142,11 +142,11 @@ describe("Parser", [&]() {
         TSNode last = ts_node_named_child(root, 2);
 
         AssertThat(ts_node_name(error, doc), Equals("ERROR"));
-        AssertThat(ts_node_pos(error).bytes, Equals(strlen("  [123, ")));
-        AssertThat(ts_node_size(error).bytes, Equals<size_t>(0))
+        AssertThat(ts_node_start_byte(error), Equals(strlen("  [123, ")));
+        AssertThat(ts_node_end_byte(error), Equals(strlen("  [123, ")))
 
         AssertThat(ts_node_name(last, doc), Equals("true"));
-        AssertThat(ts_node_pos(last).bytes, Equals(strlen("  [123, , ")));
+        AssertThat(ts_node_start_byte(last), Equals(strlen("  [123, , ")));
       });
     });
   });
@@ -293,9 +293,9 @@ describe("Parser", [&]() {
           AssertThat(ts_node_string(root, doc), Equals(
             "(program (product (variable) (number)))"));
 
-          TSNode node = ts_node_named_descendent_for_range(root, 1, 1);
+          TSNode node = ts_node_named_descendant_for_range(root, 1, 1);
           AssertThat(ts_node_name(node, doc), Equals("variable"));
-          AssertThat(ts_node_size(node).bytes, Equals(strlen("abXYZc")));
+          AssertThat(ts_node_end_byte(node), Equals(strlen("abXYZc")));
         });
       });
 
@@ -313,9 +313,9 @@ describe("Parser", [&]() {
           AssertThat(ts_node_string(root, doc), Equals(
             "(program (product (variable) (number)))"));
 
-          TSNode node = ts_node_named_descendent_for_range(root, 1, 1);
+          TSNode node = ts_node_named_descendant_for_range(root, 1, 1);
           AssertThat(ts_node_name(node, doc), Equals("variable"));
-          AssertThat(ts_node_size(node).bytes, Equals(strlen("abcXYZ")));
+          AssertThat(ts_node_end_byte(node), Equals(strlen("abcXYZ")));
         });
       });
 
@@ -422,7 +422,8 @@ describe("Parser", [&]() {
 
         TSNode comment = ts_node_named_child(root, 1);
 
-        AssertThat(ts_node_size(comment).bytes, Equals(strlen("# this is a comment")));
+        AssertThat(ts_node_start_byte(comment), Equals(strlen("x ")));
+        AssertThat(ts_node_end_byte(comment), Equals(strlen("x # this is a comment")));
       });
     });
 
@@ -433,8 +434,8 @@ describe("Parser", [&]() {
       AssertThat(ts_node_string(root, doc), Equals(
         "(program (variable) (comment))"));
 
-      AssertThat(ts_node_size(root).chars, Equals(strlen("x # OOO - DD")));
-      AssertThat(ts_node_size(root).bytes, Equals(strlen("x # \u03A9\u03A9\u03A9 \u2014 \u0394\u0394")));
+      AssertThat(ts_node_end_char(root), Equals(strlen("x # OOO - DD")));
+      AssertThat(ts_node_end_byte(root), Equals(strlen("x # \u03A9\u03A9\u03A9 \u2014 \u0394\u0394")));
     });
   });
 });

--- a/spec/runtime/tree_spec.cc
+++ b/spec/runtime/tree_spec.cc
@@ -31,8 +31,8 @@ describe("Tree", []() {
   TSSymbolMetadata invisible = {false, false, false};
 
   before_each([&]() {
-    tree1 = ts_tree_make_leaf(cat, {2, 1}, {5, 4}, ts_point_zero(), ts_point_zero(), visible);
-    tree2 = ts_tree_make_leaf(cat, {1, 1}, {3, 3}, ts_point_zero(), ts_point_zero(), visible);
+    tree1 = ts_tree_make_leaf(cat, {2, 1, 0, 1}, {5, 4, 0, 4}, visible);
+    tree2 = ts_tree_make_leaf(cat, {1, 1, 0, 1}, {3, 3, 0, 3}, visible);
     parent1 = ts_tree_make_node(dog, 2, tree_array({
       tree1,
       tree2,
@@ -57,8 +57,6 @@ describe("Tree", []() {
       TSTree *error_tree = ts_tree_make_error(
         ts_length_zero(),
         ts_length_zero(),
-        ts_point_zero(),
-        ts_point_zero(),
         'z');
 
       AssertThat(ts_tree_is_fragile_left(error_tree), IsTrue());
@@ -149,13 +147,13 @@ describe("Tree", []() {
 
     before_each([&]() {
       tree = ts_tree_make_node(cat, 3, tree_array({
-        ts_tree_make_leaf(dog, {2, 2}, {3, 3}, {1, 2}, {1, 3}, visible),
-        ts_tree_make_leaf(eel, {2, 2}, {3, 3}, {1, 2}, {1, 3}, visible),
-        ts_tree_make_leaf(fox, {2, 2}, {3, 3}, {1, 2}, {1, 3}, visible),
+        ts_tree_make_leaf(dog, {2, 2, 0, 2}, {3, 3, 0, 3}, visible),
+        ts_tree_make_leaf(eel, {2, 2, 0, 2}, {3, 3, 0, 3}, visible),
+        ts_tree_make_leaf(fox, {2, 2, 0, 2}, {3, 3, 0, 3}, visible),
       }), visible);
 
-      AssertThat(tree->padding, Equals<TSLength>({2, 2}));
-      AssertThat(tree->size, Equals<TSLength>({13, 13}));
+      AssertThat(tree->padding, Equals<TSLength>({2, 2, 0, 2}));
+      AssertThat(tree->size, Equals<TSLength>({13, 13, 0, 13}));
     });
 
     after_each([&]() {
@@ -178,16 +176,16 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->options.has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 3}));
-        AssertThat(tree->size, Equals<TSLength>({13, 13}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 3, 0, 0}));
+        AssertThat(tree->size, Equals<TSLength>({13, 13, 0, 13}));
 
         AssertThat(tree->children[0]->options.has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 3}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 3, 0, 0}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, 0, 3}));
 
         AssertThat(tree->children[1]->options.has_changes, IsFalse());
-        AssertThat(tree->children[1]->padding, Equals<TSLength>({2, 2}));
-        AssertThat(tree->children[1]->size, Equals<TSLength>({3, 3}));
+        AssertThat(tree->children[1]->padding, Equals<TSLength>({2, 2, 0, 2}));
+        AssertThat(tree->children[1]->size, Equals<TSLength>({3, 3, 0, 3}));
       });
     });
 
@@ -198,12 +196,12 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->options.has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 5}));
-        AssertThat(tree->size, Equals<TSLength>({0, 11}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 5, 0, 0}));
+        AssertThat(tree->size, Equals<TSLength>({0, 11, 0, 0}));
 
         AssertThat(tree->children[0]->options.has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 5}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 1}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 5, 0, 0}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 1, 0, 0}));
       });
     });
 
@@ -214,12 +212,12 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->options.has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 4}));
-        AssertThat(tree->size, Equals<TSLength>({13, 13}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 4, 0, 0}));
+        AssertThat(tree->size, Equals<TSLength>({13, 13, 0, 13}));
 
         AssertThat(tree->children[0]->options.has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, 0, 0}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, 0, 3}));
 
         AssertThat(tree->children[1]->options.has_changes, IsFalse());
       });
@@ -232,12 +230,12 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->options.has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({2, 2}));
-        AssertThat(tree->size, Equals<TSLength>({0, 16}));
+        AssertThat(tree->padding, Equals<TSLength>({2, 2, 0, 2}));
+        AssertThat(tree->size, Equals<TSLength>({0, 16, 0, 0}));
 
         AssertThat(tree->children[0]->options.has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({2, 2}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 6}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({2, 2, 0, 2}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 6, 0, 0}));
 
         AssertThat(tree->children[1]->options.has_changes, IsFalse());
       });
@@ -250,30 +248,30 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->options.has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 4}));
-        AssertThat(tree->size, Equals<TSLength>({0, 4}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 4, 0, 0}));
+        AssertThat(tree->size, Equals<TSLength>({0, 4, 0, 0}));
 
         AssertThat(tree->children[0]->options.has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 0}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, 0, 0}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 0, 0, 0}));
 
         AssertThat(tree->children[1]->options.has_changes, IsTrue());
-        AssertThat(tree->children[1]->padding, Equals<TSLength>({0, 0}));
-        AssertThat(tree->children[1]->size, Equals<TSLength>({0, 0}));
+        AssertThat(tree->children[1]->padding, Equals<TSLength>({0, 0, 0, 0}));
+        AssertThat(tree->children[1]->size, Equals<TSLength>({0, 0, 0, 0}));
 
         AssertThat(tree->children[2]->options.has_changes, IsTrue());
-        AssertThat(tree->children[2]->padding, Equals<TSLength>({0, 1}));
-        AssertThat(tree->children[2]->size, Equals<TSLength>({3, 3}));
+        AssertThat(tree->children[2]->padding, Equals<TSLength>({0, 1, 0, 0}));
+        AssertThat(tree->children[2]->size, Equals<TSLength>({3, 3, 0, 3}));
       });
     });
   });
 
   describe("equality", [&]() {
     it("returns true for identical trees", [&]() {
-      TSTree *tree1_copy = ts_tree_make_leaf(cat, {2, 1}, {5, 4}, {1, 1}, {1, 4}, visible);
+      TSTree *tree1_copy = ts_tree_make_leaf(cat, {2, 1, 1, 1}, {5, 4, 1, 4}, visible);
       AssertThat(ts_tree_eq(tree1, tree1_copy), IsTrue());
 
-      TSTree *tree2_copy = ts_tree_make_leaf(cat, {1, 1}, {3, 3}, {1, 1}, {1, 3}, visible);
+      TSTree *tree2_copy = ts_tree_make_leaf(cat, {1, 1, 0, 1}, {3, 3, 0, 3}, visible);
       AssertThat(ts_tree_eq(tree2, tree2_copy), IsTrue());
 
       TSTree *parent2 = ts_tree_make_node(dog, 2, tree_array({
@@ -293,8 +291,6 @@ describe("Tree", []() {
         tree1->symbol + 1,
         tree1->padding,
         tree1->size,
-				tree1->padding_point,
-				tree1->size_point,
         visible);
 
       AssertThat(ts_tree_eq(tree1, different_tree), IsFalse());
@@ -302,17 +298,17 @@ describe("Tree", []() {
     });
 
     it("returns false for trees with different options", [&]() {
-      TSTree *tree1_copy = ts_tree_make_leaf(cat, tree1->padding, tree1->size, tree1->padding_point, tree1->size_point, invisible);
+      TSTree *tree1_copy = ts_tree_make_leaf(cat, tree1->padding, tree1->size, invisible);
       AssertThat(ts_tree_eq(tree1, tree1_copy), IsFalse());
       ts_tree_release(tree1_copy);
     });
 
-    it("returns false for trees with different 2D dimensions", [&]() {
-      TSTree *tree1_copy = ts_tree_make_leaf(cat, tree1->padding, tree1->size, {5, 10}, tree1->size_point, invisible);
+    it("returns false for trees with different sizes", [&]() {
+      TSTree *tree1_copy = ts_tree_make_leaf(cat, {2, 1, 0, 1}, tree1->size, invisible);
       AssertThat(ts_tree_eq(tree1, tree1_copy), IsFalse());
       ts_tree_release(tree1_copy);
 
-      tree1_copy = ts_tree_make_leaf(cat, tree1->padding, tree1->size, tree1->padding_point, {5, 10}, invisible);
+      tree1_copy = ts_tree_make_leaf(cat, tree1->padding, {5, 4, 1, 10}, invisible);
       AssertThat(ts_tree_eq(tree1, tree1_copy), IsFalse());
       ts_tree_release(tree1_copy);
     });
@@ -322,8 +318,6 @@ describe("Tree", []() {
         tree1->symbol + 1,
         tree1->padding,
         tree1->size,
-				tree1->padding_point,
-				tree1->size_point,
         visible);
 
       TSTree *different_parent = ts_tree_make_node(dog, 2, tree_array({

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -1,7 +1,6 @@
 #include "tree_sitter/parser.h"
 #include "runtime/node.h"
 #include "runtime/tree.h"
-#include "runtime/length.h"
 #include "runtime/parser.h"
 #include "runtime/string_input.h"
 #include "runtime/document.h"
@@ -85,7 +84,7 @@ void ts_document_invalidate(TSDocument *self) {
 }
 
 TSNode ts_document_root_node(const TSDocument *self) {
-  TSNode result = ts_node_make(self->tree, ts_length_zero(), 0);
+  TSNode result = ts_node_make(self->tree, 0, 0, 0);
   while (result.data && !ts_tree_is_visible(result.data))
     result = ts_node_named_child(result, 0);
   return result;

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -53,7 +53,7 @@ void ts_document_edit(TSDocument *self, TSInputEdit edit) {
   if (!self->tree)
     return;
 
-  size_t max_chars = ts_tree_total_size(self->tree).chars;
+  size_t max_chars = ts_tree_total_chars(self->tree);
   if (edit.position > max_chars)
     edit.position = max_chars;
   if (edit.chars_removed > max_chars - edit.position)

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -1,7 +1,7 @@
 #ifndef RUNTIME_LENGTH_H_
 #define RUNTIME_LENGTH_H_
 
-#include "tree_sitter/runtime.h"
+#include "tree_sitter/parser.h"
 #include <stdbool.h>
 
 static inline TSLength ts_length_add(TSLength len1, TSLength len2) {

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -4,82 +4,69 @@
 #include "tree_sitter/parser.h"
 #include <stdbool.h>
 
+static inline bool ts_length_is_unknown(TSLength self) {
+  return self.chars > 0 && self.bytes == 0;
+}
+
+static inline void ts_length_set_unknown(TSLength *self) {
+  self->bytes = 0;
+  self->rows = 0;
+  self->columns = 0;
+}
+
 static inline TSLength ts_length_add(TSLength len1, TSLength len2) {
   TSLength result;
-  result.bytes = len1.bytes + len2.bytes;
   result.chars = len1.chars + len2.chars;
 
-  if ((len1.chars > 0 && len1.bytes == 0) || (len2.chars > 0 && len2.bytes == 0))
+  if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
     result.bytes = 0;
+    result.rows = 0;
+    result.columns = result.chars;
+  } else {
+    result.bytes = len1.bytes + len2.bytes;
+    if (len2.rows == 0) {
+      result.rows = len1.rows;
+      result.columns = len1.columns + len2.columns;
+    } else {
+      result.rows = len1.rows + len2.rows;
+      result.columns = len2.columns;
+    }
+  }
 
   return result;
 }
 
 static inline TSLength ts_length_sub(TSLength len1, TSLength len2) {
   TSLength result;
-  result.bytes = len1.bytes - len2.bytes;
   result.chars = len1.chars - len2.chars;
 
-  if ((len1.chars > 0 && len1.bytes == 0) || (len2.chars > 0 && len2.bytes == 0))
+  if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
     result.bytes = 0;
+    result.rows = 0;
+    result.columns = result.chars;
+  } else {
+    result.bytes = len1.bytes - len2.bytes;
+    if (len1.rows == len2.rows) {
+      result.rows = 0;
+      result.columns = len1.columns - len2.columns;
+    } else {
+      result.rows = len1.rows - len2.rows;
+      result.columns = len1.columns;
+    }
+  }
 
   return result;
-}
-
-static inline TSPoint ts_point_make(size_t row, size_t column) {
-  TSPoint point;
-  point.row = row;
-  point.column = column;
-  return point;
-}
-
-static inline TSPoint ts_point_add(TSPoint point1, TSPoint point2) {
-  size_t row = point1.row + point2.row;
-
-  size_t column;
-  if (point2.row == 0) {
-    column = point1.column + point2.column;
-  } else {
-    column = point2.column;
-  }
-
-  return ts_point_make(row, column);
-}
-
-static inline TSPoint ts_point_sub(TSPoint point1, TSPoint point2) {
-  size_t row, column;
-  if (point1.row == point2.row) {
-    row = 0;
-    column = point1.column - point2.column;
-  } else {
-    row = point1.row - point2.row;
-    column = point1.column;
-  }
-
-  return ts_point_make(row, column);
 }
 
 static inline TSLength ts_length_zero() {
-  TSLength result;
-  result.bytes = result.chars = 0;
-  return result;
+  return (TSLength){0, 0, 0, 0};
 }
 
-static inline bool ts_length_eq(TSLength len1, TSLength len2) {
-  return len1.bytes == len2.bytes && len1.chars == len2.chars;
-}
-
-static inline TSPoint ts_point_zero() {
-  TSPoint point;
-  point.row = point.column = 0;
-  return point;
-}
-
-static inline TSLength ts_length_make(size_t bytes, size_t chars) {
-  TSLength result;
-  result.bytes = bytes;
-  result.chars = chars;
-  return result;
+static inline bool ts_length_eq(TSLength self, TSLength other) {
+  return self.bytes == other.bytes &&
+    self.chars == other.chars &&
+    self.rows == other.rows &&
+    self.columns == other.columns;
 }
 
 #endif

--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -24,7 +24,7 @@ static void ts_lexer__get_chunk(TSLexer *self) {
   TSInput input = self->input;
   if (!self->chunk ||
       self->current_position.bytes != self->chunk_start + self->chunk_size)
-    input.seek_fn(input.payload, self->current_position);
+    input.seek_fn(input.payload, self->current_position.chars, self->current_position.bytes);
 
   self->chunk_start = self->current_position.bytes;
   self->chunk = input.read_fn(input.payload, &self->chunk_size);

--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -51,10 +51,8 @@ static void ts_lexer__start(TSLexer *self, TSStateId lex_state) {
 }
 
 static void ts_lexer__start_token(TSLexer *self) {
-  LOG("start_token chars:%lu, rows:%lu, columns:%lu", self->current_position.chars, self->current_point.row, self->current_point.column);
-
+  LOG("start_token chars:%lu, rows:%lu, columns:%lu", self->current_position.chars, self->current_position.rows, self->current_position.columns);
   self->token_start_position = self->current_position;
-  self->token_start_point = self->current_point;
 }
 
 static bool ts_lexer__advance(TSLexer *self, TSStateId state) {
@@ -65,13 +63,13 @@ static bool ts_lexer__advance(TSLexer *self, TSStateId state) {
 
   if (self->lookahead_size) {
     self->current_position.bytes += self->lookahead_size;
-    self->current_position.chars += 1;
+    self->current_position.chars++;
 
     if (self->lookahead == '\n') {
-      self->current_point.row += 1;
-      self->current_point.column = 0;
+      self->current_position.rows++;
+      self->current_position.columns = 0;
     } else {
-      self->current_point.column += 1;
+      self->current_position.columns++;
     }
   }
 
@@ -85,22 +83,16 @@ static bool ts_lexer__advance(TSLexer *self, TSStateId state) {
 static TSTree *ts_lexer__accept(TSLexer *self, TSSymbol symbol,
                                 TSSymbolMetadata metadata,
                                 const char *symbol_name) {
-  TSLength size =
-    ts_length_sub(self->current_position, self->token_start_position);
-  TSLength padding =
-    ts_length_sub(self->token_start_position, self->token_end_position);
+  TSLength size = ts_length_sub(self->current_position, self->token_start_position);
+  TSLength padding = ts_length_sub(self->token_start_position, self->token_end_position);
   self->token_end_position = self->current_position;
-
-  TSPoint size_point = ts_point_sub(self->current_point, self ->token_start_point);
-  TSPoint padding_point = ts_point_sub(self->token_start_point, self->token_end_point);
-  self->token_end_point = self->current_point;
 
   if (symbol == ts_builtin_sym_error) {
     LOG("error_char");
-    return ts_tree_make_error(size, padding, size_point, padding_point, self->lookahead);
+    return ts_tree_make_error(size, padding, self->lookahead);
   } else {
     LOG("accept_token sym:%s", symbol_name);
-    return ts_tree_make_leaf(symbol, padding, size, padding_point, size_point, metadata);
+    return ts_tree_make_leaf(symbol, padding, size, metadata);
   }
 }
 
@@ -119,18 +111,14 @@ TSLexer ts_lexer_make() {
     .chunk_start = 0,
     .debugger = ts_debugger_null(),
   };
-  ts_lexer_reset(&result, ts_length_zero(), ts_point_zero());
+  ts_lexer_reset(&result, ts_length_zero());
   return result;
 }
 
-static inline void ts_lexer__reset(TSLexer *self, TSLength position, TSPoint point) {
+static inline void ts_lexer__reset(TSLexer *self, TSLength position) {
   self->token_start_position = position;
   self->token_end_position = position;
   self->current_position = position;
-
-  self->token_start_point = point;
-  self->token_end_point = point;
-  self->current_point = point;
 
   self->chunk = 0;
   self->chunk_start = 0;
@@ -141,11 +129,11 @@ static inline void ts_lexer__reset(TSLexer *self, TSLength position, TSPoint poi
 
 void ts_lexer_set_input(TSLexer *self, TSInput input) {
   self->input = input;
-  ts_lexer__reset(self, ts_length_zero(), ts_point_zero());
+  ts_lexer__reset(self, ts_length_zero());
 }
 
-void ts_lexer_reset(TSLexer *self, TSLength position, TSPoint point) {
+void ts_lexer_reset(TSLexer *self, TSLength position) {
   if (!ts_length_eq(position, self->current_position))
-    ts_lexer__reset(self, position, point);
+    ts_lexer__reset(self, position);
     return;
 }

--- a/src/runtime/lexer.h
+++ b/src/runtime/lexer.h
@@ -9,7 +9,7 @@ extern "C" {
 
 TSLexer ts_lexer_make();
 void ts_lexer_set_input(TSLexer *, TSInput);
-void ts_lexer_reset(TSLexer *, TSLength, TSPoint);
+void ts_lexer_reset(TSLexer *, TSLength);
 
 #ifdef __cplusplus
 }

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -1,6 +1,5 @@
 #include <stdbool.h>
 #include "runtime/node.h"
-#include "runtime/length.h"
 #include "runtime/tree.h"
 #include "runtime/document.h"
 
@@ -49,7 +48,7 @@ static inline TSNode ts_node__direct_parent(TSNode self, size_t *index) {
     tree->context.parent,
     ts_node__offset_char(self) - tree->context.offset.chars,
     ts_node__offset_byte(self) - tree->context.offset.bytes,
-    ts_node__offset_row(self) - tree->context.offset_point.row
+    ts_node__offset_row(self) - tree->context.offset.rows
   );
 }
 
@@ -59,7 +58,7 @@ static inline TSNode ts_node__direct_child(TSNode self, size_t i) {
     child_tree,
     ts_node__offset_char(self) + child_tree->context.offset.chars,
     ts_node__offset_byte(self) + child_tree->context.offset.bytes,
-    ts_node__offset_row(self) + child_tree->context.offset_point.row
+    ts_node__offset_row(self) + child_tree->context.offset.rows
   );
 }
 
@@ -189,11 +188,18 @@ size_t ts_node_end_byte(TSNode self) {
 
 TSPoint ts_node_start_point(TSNode self) {
   const TSTree *tree = ts_node__tree(self);
-  return ts_point_make(ts_node__offset_row(self) + tree->padding_point.row, ts_tree_offset_column(tree));
+  return (TSPoint){
+    ts_node__offset_row(self) + tree->padding.rows,
+    ts_tree_start_column(tree)
+  };
 }
 
 TSPoint ts_node_end_point(TSNode self) {
-  return ts_point_add(ts_node_start_point(self), ts_node__tree(self)->size_point);
+  const TSTree *tree = ts_node__tree(self);
+  return (TSPoint){
+    ts_node__offset_row(self) + tree->padding.rows + tree->size.rows,
+    ts_tree_end_column(tree)
+  };
 }
 
 TSSymbol ts_node_symbol(TSNode self) {

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -4,8 +4,8 @@
 #include "runtime/tree.h"
 #include "runtime/document.h"
 
-TSNode ts_node_make(const TSTree *tree, TSLength offset, size_t row) {
-  return (TSNode){.data = tree, .offset = offset, .row = row };
+TSNode ts_node_make(const TSTree *tree, size_t chars, size_t byte, size_t row) {
+  return (TSNode){.data = tree, .offset = {chars, byte, row} };
 }
 
 /*
@@ -13,57 +13,83 @@ TSNode ts_node_make(const TSTree *tree, TSLength offset, size_t row) {
  */
 
 static inline TSNode ts_node__null() {
-  return ts_node_make(NULL, ts_length_zero(), 0);
+  return ts_node_make(NULL, 0, 0, 0);
 }
 
 static inline const TSTree *ts_node__tree(TSNode self) {
   return self.data;
 }
 
-static inline TSLength ts_node__offset(TSNode self) {
-  return self.offset;
+static inline size_t ts_node__offset_char(TSNode self) {
+  return self.offset[0];
 }
 
-static inline bool ts_tree__is_relevant(const TSTree *tree, bool include_anonymous) {
+static inline size_t ts_node__offset_byte(TSNode self) {
+  return self.offset[1];
+}
+
+static inline size_t ts_node__offset_row(TSNode self) {
+  return self.offset[2];
+}
+
+static inline bool ts_node__is_relevant(TSNode self, bool include_anonymous) {
+  const TSTree *tree = ts_node__tree(self);
   return include_anonymous ? tree->options.visible : tree->options.named;
 }
 
-static inline size_t ts_tree__relevant_child_count(const TSTree *tree,
-                                                   bool include_anonymous) {
+static inline size_t ts_node__relevant_child_count(TSNode self, bool include_anonymous) {
+  const TSTree *tree = ts_node__tree(self);
   return include_anonymous ? tree->visible_child_count : tree->named_child_count;
+}
+
+static inline TSNode ts_node__direct_parent(TSNode self, size_t *index) {
+  const TSTree *tree = ts_node__tree(self);
+  *index = tree->context.index;
+  return ts_node_make(
+    tree->context.parent,
+    ts_node__offset_char(self) - tree->context.offset.chars,
+    ts_node__offset_byte(self) - tree->context.offset.bytes,
+    ts_node__offset_row(self) - tree->context.offset_point.row
+  );
+}
+
+static inline TSNode ts_node__direct_child(TSNode self, size_t i) {
+  const TSTree *child_tree = ts_node__tree(self)->children[i];
+  return ts_node_make(
+    child_tree,
+    ts_node__offset_char(self) + child_tree->context.offset.chars,
+    ts_node__offset_byte(self) + child_tree->context.offset.bytes,
+    ts_node__offset_row(self) + child_tree->context.offset_point.row
+  );
 }
 
 static inline TSNode ts_node__child(TSNode self, size_t child_index,
                                     bool include_anonymous) {
-  const TSTree *tree = ts_node__tree(self);
-  TSLength position = ts_node__offset(self);
-  size_t offset_row = self.row;
-
+  TSNode result = self;
   bool did_descend = true;
+
   while (did_descend) {
     did_descend = false;
 
     size_t index = 0;
-    for (size_t i = 0; i < tree->child_count; i++) {
-      TSTree *child = tree->children[i];
-      if (ts_tree__is_relevant(child, include_anonymous)) {
+    for (size_t i = 0; i < ts_node__tree(result)->child_count; i++) {
+      TSNode child = ts_node__direct_child(result, i);
+      if (ts_node__is_relevant(child, include_anonymous)) {
         if (index == child_index)
-          return ts_node_make(child, position, offset_row);
+          return child;
         index++;
       } else {
         size_t grandchild_index = child_index - index;
         size_t grandchild_count =
-          ts_tree__relevant_child_count(child, include_anonymous);
+          ts_node__relevant_child_count(child, include_anonymous);
         if (grandchild_index < grandchild_count) {
           did_descend = true;
-          tree = child;
+          result = child;
           child_index = grandchild_index;
           break;
         }
         index += grandchild_count;
       }
-      position = ts_length_add(position, ts_tree_total_size(child));
-      offset_row += child->padding_point.row + child->size_point.row;
     }
   }
 
@@ -71,59 +97,45 @@ static inline TSNode ts_node__child(TSNode self, size_t child_index,
 }
 
 static inline TSNode ts_node__prev_sibling(TSNode self, bool include_anonymous) {
-  const TSTree *tree = ts_node__tree(self);
-  TSLength offset = ts_node__offset(self);
-  size_t offset_row = self.row;
+  TSNode result = self;
 
   do {
-    size_t index = tree->context.index;
-    offset = ts_length_sub(offset, tree->context.offset);
-    offset_row -= tree->context.offset_point.row;
-    tree = tree->context.parent;
-    if (!tree)
+    size_t index;
+    result = ts_node__direct_parent(result, &index);
+    if (!result.data)
       break;
 
     for (size_t i = index - 1; i + 1 > 0; i--) {
-      const TSTree *child = tree->children[i];
-      TSLength child_offset = ts_length_add(offset, child->context.offset);
-      size_t child_offset_row = offset_row + child->context.offset_point.row;
-      if (ts_tree__is_relevant(child, include_anonymous))
-        return ts_node_make(child, child_offset, child_offset_row);
-      size_t grandchild_count = ts_tree__relevant_child_count(child, include_anonymous);
+      TSNode child = ts_node__direct_child(result, i);
+      if (ts_node__is_relevant(child, include_anonymous))
+        return child;
+      size_t grandchild_count = ts_node__relevant_child_count(child, include_anonymous);
       if (grandchild_count > 0)
-        return ts_node__child(ts_node_make(child, child_offset, child_offset_row),
-                              grandchild_count - 1, include_anonymous);
+        return ts_node__child(child, grandchild_count - 1, include_anonymous);
     }
-  } while (!ts_tree_is_visible(tree));
+  } while (!ts_tree_is_visible(ts_node__tree(result)));
 
   return ts_node__null();
 }
 
 static inline TSNode ts_node__next_sibling(TSNode self, bool include_anonymous) {
-  const TSTree *tree = ts_node__tree(self);
-  TSLength offset = ts_node__offset(self);
-  size_t offset_row = self.row;
+  TSNode result = self;
 
   do {
-    size_t index = tree->context.index;
-    offset = ts_length_sub(offset, tree->context.offset);
-    offset_row -= tree->context.offset_point.row;
-    tree = tree->context.parent;
-    if (!tree)
+    size_t index;
+    result = ts_node__direct_parent(result, &index);
+    if (!result.data)
       break;
 
-    for (size_t i = index + 1; i < tree->child_count; i++) {
-      const TSTree *child = tree->children[i];
-      TSLength child_offset = ts_length_add(offset, child->context.offset);
-      size_t child_offset_row = offset_row + child->context.offset_point.row;
-      if (ts_tree__is_relevant(child, include_anonymous))
-        return ts_node_make(child, child_offset, child_offset_row);
-      size_t grandchild_count = ts_tree__relevant_child_count(child, include_anonymous);
+    for (size_t i = index + 1; i < ts_node__tree(result)->child_count; i++) {
+      TSNode child = ts_node__direct_child(result, i);
+      if (ts_node__is_relevant(child, include_anonymous))
+        return child;
+      size_t grandchild_count = ts_node__relevant_child_count(child, include_anonymous);
       if (grandchild_count > 0)
-        return ts_node__child(ts_node_make(child, child_offset, child_offset_row), 0,
-                              include_anonymous);
+        return ts_node__child(child, 0, include_anonymous);
     }
-  } while (!ts_tree_is_visible(tree));
+  } while (!ts_tree_is_visible(ts_node__tree(result)));
 
   return ts_node__null();
 }
@@ -131,34 +143,28 @@ static inline TSNode ts_node__next_sibling(TSNode self, bool include_anonymous) 
 static inline TSNode ts_node__descendant_for_range(TSNode self, size_t min,
                                                    size_t max,
                                                    bool include_anonymous) {
-  const TSTree *tree = ts_node__tree(self), *last_visible_tree = tree;
-  TSLength offset = ts_node__offset(self), last_visible_position = offset;
-  size_t offset_row = self.row, last_visible_row = offset_row;
+  TSNode node = self;
+  TSNode last_visible_node = self;
 
   bool did_descend = true;
   while (did_descend) {
     did_descend = false;
 
-    for (size_t i = 0; i < tree->child_count; i++) {
-      const TSTree *child = tree->children[i];
-      if (offset.chars + child->padding.chars > min)
+    for (size_t i = 0; i < ts_node__tree(node)->child_count; i++) {
+      TSNode child = ts_node__direct_child(node, i);
+      if (ts_node_start_char(child) > min)
         break;
-      if (offset.chars + child->padding.chars + child->size.chars > max) {
-        tree = child;
-        if (ts_tree__is_relevant(child, include_anonymous)) {
-          last_visible_tree = tree;
-          last_visible_position = offset;
-          last_visible_row = offset_row;
-        }
+      if (ts_node_end_char(child) > max) {
+        node = child;
+        if (ts_node__is_relevant(node, include_anonymous))
+          last_visible_node = node;
         did_descend = true;
         break;
       }
-      offset = ts_length_add(offset, ts_tree_total_size(child));
-      offset_row += child->padding_point.row + child->size_point.row;
     }
   }
 
-  return ts_node_make(last_visible_tree, last_visible_position, last_visible_row);
+  return last_visible_node;
 }
 
 /*
@@ -166,7 +172,7 @@ static inline TSNode ts_node__descendant_for_range(TSNode self, size_t min,
  */
 
 size_t ts_node_start_char(TSNode self) {
-  return ts_node__offset(self).chars + ts_node__tree(self)->padding.chars;
+  return ts_node__offset_char(self) + ts_node__tree(self)->padding.chars;
 }
 
 size_t ts_node_end_char(TSNode self) {
@@ -174,24 +180,20 @@ size_t ts_node_end_char(TSNode self) {
 }
 
 size_t ts_node_start_byte(TSNode self) {
-  return ts_node__offset(self).bytes + ts_node__tree(self)->padding.bytes;
+  return ts_node__offset_byte(self) + ts_node__tree(self)->padding.bytes;
 }
 
 size_t ts_node_end_byte(TSNode self) {
   return ts_node_start_byte(self) + ts_node__tree(self)->size.bytes;
 }
 
-TSPoint ts_node_size_point(TSNode self) {
-  return ts_node__tree(self)->size_point;
-}
-
 TSPoint ts_node_start_point(TSNode self) {
   const TSTree *tree = ts_node__tree(self);
-  return ts_point_make(self.row + tree->padding_point.row, ts_tree_offset_column(tree));
+  return ts_point_make(ts_node__offset_row(self) + tree->padding_point.row, ts_tree_offset_column(tree));
 }
 
 TSPoint ts_node_end_point(TSNode self) {
-  return ts_point_add(ts_node_start_point(self), ts_node_size_point(self));
+  return ts_point_add(ts_node_start_point(self), ts_node__tree(self)->size_point);
 }
 
 TSSymbol ts_node_symbol(TSNode self) {
@@ -209,8 +211,9 @@ const char *ts_node_string(TSNode self, const TSDocument *document) {
 
 bool ts_node_eq(TSNode self, TSNode other) {
   return ts_tree_eq(ts_node__tree(self), ts_node__tree(other)) &&
-         ts_length_eq(ts_node__offset(self), ts_node__offset(other)) &&
-         self.row == other.row;
+         self.offset[0] == other.offset[0] &&
+         self.offset[1] == other.offset[1] &&
+         self.offset[2] == other.offset[2];
 }
 
 bool ts_node_is_named(TSNode self) {
@@ -222,20 +225,16 @@ bool ts_node_has_changes(TSNode self) {
 }
 
 TSNode ts_node_parent(TSNode self) {
-  const TSTree *tree = ts_node__tree(self);
-  TSLength offset = ts_node__offset(self);
-	size_t offset_row = self.row;
+  TSNode result = self;
+  size_t index;
 
   do {
-    offset = ts_length_sub(offset, tree->context.offset);
-		offset_row -= tree->context.offset_point.row;
-
-    tree = tree->context.parent;
-    if (!tree)
+    result = ts_node__direct_parent(result, &index);
+    if (!result.data)
       return ts_node__null();
-  } while (!ts_tree_is_visible(tree));
+  } while (!ts_tree_is_visible(result.data));
 
-  return ts_node_make(tree, offset, offset_row);
+  return result;
 }
 
 TSNode ts_node_child(TSNode self, size_t child_index) {

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -128,7 +128,7 @@ static inline TSNode ts_node__next_sibling(TSNode self, bool include_anonymous) 
   return ts_node__null();
 }
 
-static inline TSNode ts_node__descendent_for_range(TSNode self, size_t min,
+static inline TSNode ts_node__descendant_for_range(TSNode self, size_t min,
                                                    size_t max,
                                                    bool include_anonymous) {
   const TSTree *tree = ts_node__tree(self), *last_visible_tree = tree;
@@ -165,12 +165,20 @@ static inline TSNode ts_node__descendent_for_range(TSNode self, size_t min,
  *  Public
  */
 
-TSLength ts_node_pos(TSNode self) {
-  return ts_length_add(ts_node__offset(self), ts_node__tree(self)->padding);
+size_t ts_node_start_char(TSNode self) {
+  return ts_node__offset(self).chars + ts_node__tree(self)->padding.chars;
 }
 
-TSLength ts_node_size(TSNode self) {
-  return ts_node__tree(self)->size;
+size_t ts_node_end_char(TSNode self) {
+  return ts_node_start_char(self) + ts_node__tree(self)->size.chars;
+}
+
+size_t ts_node_start_byte(TSNode self) {
+  return ts_node__offset(self).bytes + ts_node__tree(self)->padding.bytes;
+}
+
+size_t ts_node_end_byte(TSNode self) {
+  return ts_node_start_byte(self) + ts_node__tree(self)->size.bytes;
 }
 
 TSPoint ts_node_size_point(TSNode self) {
@@ -262,10 +270,10 @@ TSNode ts_node_prev_named_sibling(TSNode self) {
   return ts_node__prev_sibling(self, false);
 }
 
-TSNode ts_node_descendent_for_range(TSNode self, size_t min, size_t max) {
-  return ts_node__descendent_for_range(self, min, max, true);
+TSNode ts_node_descendant_for_range(TSNode self, size_t min, size_t max) {
+  return ts_node__descendant_for_range(self, min, max, true);
 }
 
-TSNode ts_node_named_descendent_for_range(TSNode self, size_t min, size_t max) {
-  return ts_node__descendent_for_range(self, min, max, false);
+TSNode ts_node_named_descendant_for_range(TSNode self, size_t min, size_t max) {
+  return ts_node__descendant_for_range(self, min, max, false);
 }

--- a/src/runtime/node.h
+++ b/src/runtime/node.h
@@ -2,9 +2,7 @@
 #define RUNTIME_NODE_H_
 
 #include "tree_sitter/parser.h"
-#include "runtime/length.h"
-#include "runtime/tree.h"
 
-TSNode ts_node_make(const TSTree *, TSLength, size_t);
+TSNode ts_node_make(const TSTree *, size_t character, size_t byte, size_t row);
 
 #endif

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -126,18 +126,15 @@ static StackNode *stack_node_new(StackNode *next, TSStateId state, TSTree *tree)
   ts_tree_retain(tree);
   stack_node_retain(next);
   TSLength position = ts_tree_total_size(tree);
-  TSPoint position_point = ts_tree_total_size_point(tree);
-  if (next) {
+  if (next)
     position = ts_length_add(next->entry.position, position);
-    position_point = ts_point_add(next->entry.position_point, position_point);
-  }
   *self = (StackNode){
     .ref_count = 1,
     .successor_count = 1,
     .successors = { next, NULL, NULL },
     .entry =
       {
-        .state = state, .tree = tree, .position = position, .position_point = position_point,
+        .state = state, .tree = tree, .position = position
       },
   };
   return self;

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -14,7 +14,6 @@ typedef struct {
   TSTree *tree;
   TSStateId state;
   TSLength position;
-  TSPoint position_point;
 } StackEntry;
 
 typedef struct {

--- a/src/runtime/string_input.c
+++ b/src/runtime/string_input.c
@@ -19,10 +19,10 @@ const char *ts_string_input_read(void *payload, size_t *bytes_read) {
   return input->string + previous_position;
 }
 
-int ts_string_input_seek(void *payload, TSLength position) {
+int ts_string_input_seek(void *payload, size_t character, size_t byte) {
   TSStringInput *input = (TSStringInput *)payload;
-  input->position = position.bytes;
-  return (position.bytes < input->length);
+  input->position = byte;
+  return (byte < input->length);
 }
 
 TSInput ts_string_input_make(const char *string) {

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -7,8 +7,6 @@
 #include "runtime/length.h"
 
 TSTree *ts_tree_make_leaf(TSSymbol sym, TSLength padding, TSLength size,
-                          TSPoint padding_point,
-                          TSPoint size_point,
                           TSSymbolMetadata metadata) {
   TSTree *result = malloc(sizeof(TSTree));
   *result = (TSTree){
@@ -20,8 +18,6 @@ TSTree *ts_tree_make_leaf(TSSymbol sym, TSLength padding, TSLength size,
     .named_child_count = 0,
     .children = NULL,
     .padding = padding,
-    .padding_point = padding_point,
-    .size_point = size_point,
     .options =
       {
         .visible = metadata.visible, .named = metadata.named,
@@ -36,33 +32,26 @@ TSTree *ts_tree_make_leaf(TSSymbol sym, TSLength padding, TSLength size,
   return result;
 }
 
-TSTree *ts_tree_make_error(TSLength size, TSLength padding,
-                           TSPoint size_point,
-                           TSPoint padding_point,
-                           char lookahead_char) {
+TSTree *ts_tree_make_error(TSLength size, TSLength padding, char lookahead_char) {
   TSTree *result =
-    ts_tree_make_leaf(ts_builtin_sym_error, padding, size, padding_point,
-                      size_point, (TSSymbolMetadata){
-                                       .visible = true, .named = true,
-                                     });
+    ts_tree_make_leaf(ts_builtin_sym_error, padding, size, (TSSymbolMetadata){
+                               .visible = true, .named = true,
+                             });
   result->lookahead_char = lookahead_char;
   return result;
 }
 
 void ts_tree_assign_parents(TSTree *self) {
   TSLength offset = ts_length_zero();
-  TSPoint offset_point = ts_point_zero();
   for (size_t i = 0; i < self->child_count; i++) {
     TSTree *child = self->children[i];
     if (child->context.parent != self) {
       child->context.parent = self;
       child->context.index = i;
       child->context.offset = offset;
-      child->context.offset_point = offset_point;
       ts_tree_assign_parents(child);
     }
     offset = ts_length_add(offset, ts_tree_total_size(child));
-    offset_point = ts_point_add(offset_point, ts_tree_total_size_point(child));
   }
 }
 
@@ -77,12 +66,8 @@ void ts_tree_set_children(TSTree *self, size_t child_count, TSTree **children) {
     if (i == 0) {
       self->padding = child->padding;
       self->size = child->size;
-      self->padding_point = child->padding_point;
-      self->size_point = child->size_point;
     } else {
-      self->size =
-        ts_length_add(ts_length_add(self->size, child->padding), child->size);
-      self->size_point = ts_point_add(ts_point_add(self->size_point, child->padding_point), child->size_point);
+      self->size = ts_length_add(self->size, ts_tree_total_size(child));
     }
 
     if (child->options.visible) {
@@ -106,7 +91,7 @@ void ts_tree_set_children(TSTree *self, size_t child_count, TSTree **children) {
 TSTree *ts_tree_make_node(TSSymbol symbol, size_t child_count,
                           TSTree **children, TSSymbolMetadata metadata) {
   TSTree *result =
-    ts_tree_make_leaf(symbol, ts_length_zero(), ts_length_zero(), ts_point_zero(), ts_point_zero(), metadata);
+    ts_tree_make_leaf(symbol, ts_length_zero(), ts_length_zero(), metadata);
   ts_tree_set_children(result, child_count, children);
   return result;
 }
@@ -128,32 +113,23 @@ void ts_tree_release(TSTree *self) {
   }
 }
 
-size_t ts_tree_offset_column(const TSTree *self) {
-  size_t column = self->padding_point.column;
-
-  if (self->padding_point.row > 0) {
+size_t ts_tree_start_column(const TSTree *self) {
+  size_t column = self->padding.columns;
+  if (self->padding.rows > 0)
     return column;
+  for (const TSTree *tree = self; tree != NULL; tree = tree->context.parent) {
+    column += tree->context.offset.columns;
+    if (tree->context.offset.rows > 0)
+      break;
   }
-
-  const TSTree *parent = self;
-  TSPoint offset_point;
-  do {
-    offset_point = parent->context.offset_point;
-    column += offset_point.column;
-
-    parent = parent->context.parent;
-    if (!parent) break;
-  } while (offset_point.row == 0);
-
   return column;
 }
 
-TSLength ts_tree_total_size(const TSTree *self) {
-  return ts_length_add(self->padding, self->size);
-}
-
-TSPoint ts_tree_total_size_point(const TSTree *self) {
-  return ts_point_add(self->padding_point, self->size_point);
+size_t ts_tree_end_column(const TSTree *self) {
+  size_t result = self->size.columns;
+  if (self->size.rows == 0)
+    result += ts_tree_start_column(self);
+  return result;
 }
 
 bool ts_tree_eq(const TSTree *self, const TSTree *other) {
@@ -273,26 +249,26 @@ void ts_tree_edit(TSTree *self, TSInputEdit edit) {
   size_t start = edit.position;
   size_t new_end = edit.position + edit.chars_inserted;
   size_t old_end = edit.position + edit.chars_removed;
-  assert(old_end <= ts_tree_total_size(self).chars);
+  assert(old_end <= ts_tree_total_chars(self));
 
   self->options.has_changes = true;
 
   if (start < self->padding.chars) {
-    self->padding.bytes = 0;
+    ts_length_set_unknown(&self->padding);
     long remaining_padding = self->padding.chars - old_end;
     if (remaining_padding >= 0) {
       self->padding.chars = new_end + remaining_padding;
     } else {
       self->padding.chars = new_end;
       self->size.chars += remaining_padding;
-      self->size.bytes = 0;
+      ts_length_set_unknown(&self->size);
     }
   } else if (start == self->padding.chars && edit.chars_removed == 0) {
-    self->padding.bytes = 0;
     self->padding.chars += edit.chars_inserted;
+    ts_length_set_unknown(&self->padding);
   } else {
-    self->size.bytes = 0;
     self->size.chars += (edit.chars_inserted - edit.chars_removed);
+    ts_length_set_unknown(&self->size);
   }
 
   bool found_first_child = false;
@@ -300,7 +276,7 @@ void ts_tree_edit(TSTree *self, TSInputEdit edit) {
   size_t child_left = 0, child_right = 0;
   for (size_t i = 0; i < self->child_count; i++) {
     TSTree *child = self->children[i];
-    size_t child_size = ts_tree_total_size(child).chars;
+    size_t child_size = ts_tree_total_chars(child);
     child_left = child_right;
     child_right += child_size;
 


### PR DESCRIPTION
* [x] Make 1D and 2D node accessor functions more consistent with each other.
  * Replace `ts_node_pos` with `ts_node_start_char` and `ts_node_start_byte`, to be more consistent with `ts_node_start_point`.
  * Replace `ts_node_size` with `ts_node_end_char` and `ts_node_end_byte`, to be more consistent with `ts_node_end_point`.
* [x] Eliminate the `TSLength` struct from the API. Bytes and characters are now treated separately everywhere.
* [x] Correct the spelling of the word 'descendant' in the API.
* [x] Remove duplication in the internal logic for handling 1D and 2D coordinates.

/cc @joshvera @robrix - The minor API changes in the first bullet point will affect you. I think the new functions will be more convenient.