### PR TITLE
Prevent alternative parses from getting out of sync

### DIFF
--- a/src/compiler/build_tables/remove_duplicate_states.h
+++ b/src/compiler/build_tables/remove_duplicate_states.h
@@ -8,8 +8,7 @@ namespace tree_sitter {
 namespace build_tables {
 
 template <typename StateType, typename ActionType, int advance_action>
-std::map<size_t, size_t> remove_duplicate_states(
-  std::vector<StateType> *states) {
+std::map<size_t, size_t> remove_duplicate_states(std::vector<StateType> *states) {
   std::map<size_t, size_t> replacements;
 
   while (true) {

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -198,7 +198,11 @@ static TSTree *ts_parser__get_next_lookahead(TSParser *self, int head) {
     return result;
   }
 
-  return NULL;
+  ts_lexer_reset(&self->lexer, position);
+  TSStateId parse_state = ts_stack_top_state(self->stack, head);
+  TSStateId lex_state = self->language->lex_states[parse_state];
+  LOG("lex state:%d", lex_state);
+  return self->language->lex_fn(&self->lexer, lex_state);
 }
 
 static int ts_parser__split(TSParser *self, int head) {
@@ -648,29 +652,22 @@ TSTree *ts_parser_parse(TSParser *self, TSInput input, TSTree *previous_tree) {
 
   for (;;) {
     TSTree *lookahead = NULL;
-    TSLength position = ts_length_zero(), last_position;
+    TSLength last_position = ts_length_zero();
+    TSLength position = ts_length_zero();
 
     self->is_split = ts_stack_head_count(self->stack) > 1;
+
     for (int head = 0; head < ts_stack_head_count(self->stack);) {
-      StackEntry *entry = ts_stack_head(self->stack, head);
       last_position = position;
-      position = entry ? entry->position : ts_length_zero();
+      position = ts_stack_top_position(self->stack, head);
 
       LOG("process head:%d, head_count:%d, state:%d, pos:%lu", head,
           ts_stack_head_count(self->stack),
           ts_stack_top_state(self->stack, head), position.chars);
 
-      if (!ts_parser__can_reuse(self, head, lookahead) ||
-          position.chars != last_position.chars) {
+      if (position.chars != last_position.chars ||
+          !ts_parser__can_reuse(self, head, lookahead))
         lookahead = ts_parser__get_next_lookahead(self, head);
-        if (!lookahead) {
-          ts_lexer_reset(&self->lexer, position);
-          TSStateId parse_state = ts_stack_top_state(self->stack, head);
-          TSStateId lex_state = self->language->lex_states[parse_state];
-          LOG("lex state:%d", lex_state);
-          lookahead = self->language->lex_fn(&self->lexer, lex_state);
-        }
-      }
 
       LOG("lookahead sym:%s, size:%lu", SYM_NAME(lookahead->symbol),
           ts_tree_total_chars(lookahead));

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -185,7 +185,8 @@ static TSTree *ts_parser__get_next_lookahead(TSParser *self, int head) {
     }
 
     if (!ts_parser__can_reuse(self, head, state->reusable_subtree)) {
-      LOG("breakdown_unreusable sym:%s", SYM_NAME(state->reusable_subtree->symbol));
+      LOG("breakdown_unreusable sym:%s",
+          SYM_NAME(state->reusable_subtree->symbol));
       ts_parser__breakdown_reusable_subtree(state);
       continue;
     }
@@ -511,9 +512,9 @@ static void ts_parser__accept(TSParser *self, int head) {
         TSTree *root = pop_result->trees[i];
         size_t leading_extra_count = i;
         size_t trailing_extra_count = pop_result->tree_count - 1 - i;
-        TSTree **new_children =
-          malloc((root->child_count + leading_extra_count + trailing_extra_count) *
-                 sizeof(TSTree *));
+        TSTree **new_children = malloc(
+          (root->child_count + leading_extra_count + trailing_extra_count) *
+          sizeof(TSTree *));
         memcpy(new_children, pop_result->trees,
                leading_extra_count * sizeof(TSTree *));
         memcpy(new_children + leading_extra_count, root->children,
@@ -526,7 +527,8 @@ static void ts_parser__accept(TSParser *self, int head) {
         ts_tree_set_children(root, new_count, new_children);
         ts_tree_retain(root);
         ts_parser__remove_head(self, pop_result->head_index);
-        self->finished_tree = ts_parser__select_tree(self, self->finished_tree, root);
+        self->finished_tree =
+          ts_parser__select_tree(self, self->finished_tree, root);
         break;
       }
     }

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -14,7 +14,7 @@ typedef struct {
   const TSLanguage *language;
   Vector lookahead_states;
   Vector reduce_parents;
-  int finished_stack_head;
+  TSTree *finished_tree;
   bool is_split;
 } TSParser;
 

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -220,8 +220,8 @@ static size_t ts_tree__write_to_string(const TSTree *self,
 
   char *cursor = string;
   char **writer = (limit > 0) ? &cursor : &string;
-  bool visible = is_root || (self->visible &&
-                             (include_anonymous || self->named));
+  bool visible =
+    is_root || (self->visible && (include_anonymous || self->named));
 
   if (visible && !is_root)
     cursor += snprintf(*writer, limit, " ");

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -68,7 +68,8 @@ static inline TSLength ts_tree_total_size(const TSTree *self) {
 }
 
 static inline bool ts_tree_is_fragile(const TSTree *tree) {
-  return tree->fragile_left || tree->fragile_right || ts_tree_total_chars(tree) == 0;
+  return tree->fragile_left || tree->fragile_right ||
+         ts_tree_total_chars(tree) == 0;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
For certain edits, different parses could end up reusing nodes differently such that they would fail to merge, resulting in a 2x slowdown, in the case of 2 alternative parses.